### PR TITLE
Muestra del div de fechas en caso de solicitarlo

### DIFF
--- a/script.js
+++ b/script.js
@@ -107,6 +107,7 @@ function calculateDatesExam() {
     } else {
         result.innerText = "Por favor, selecciona una materia válida.";
     }
+    result.style.display = "block";
 }
 
 

--- a/style.css
+++ b/style.css
@@ -73,6 +73,7 @@
 
         /* Resultado */
         #result {
+            display: none;
             margin-top: 20px;
             padding: 15px;
             background: #e0f2fe;


### PR DESCRIPTION
Lo trabajado aquí busca no mostrar el contenedor `.result` hasta que se solicite las fechas, para ello se modificaron los siguientes archivos:
- *style.css*:
    - Al `#result{}` se le agrego el `display: none;` para que no se muestre en primera instancia.
- *script.js*:
    - Al `calculateDatesExam()` se le agrego como última línea `result.style.display = "block";` para mostrar las fechas una vez solicitadas.

## Comparativa
### Vista actual:

https://github.com/user-attachments/assets/9a78250b-0361-4646-af25-8b533742d978

### Con los cambios:

https://github.com/user-attachments/assets/7a2525f6-67d7-4653-8a50-6ac3cb7efa64

