### PR TITLE
Eliminado del margin-top en el primer titular de exámenes 

### DIFF
--- a/script.js
+++ b/script.js
@@ -82,13 +82,13 @@ function calculateDatesExam() {
         startDates.forEach((fechaInicio, index) => {
 
             if (index === 0) {
-                result.innerHTML += `<h3 style="margin-top: 20px;">Exámenes noviembre/diciembre</h3>`;
+                result.innerHTML += "<h3>Exámenes noviembre/diciembre</h3>";
                 dateCounter = 1;
             } else if (index === 2) {
-                result.innerHTML += `<h3 style="margin-top: 20px;">Exámenes enero/febrero</h3>`;
+                result.innerHTML += "<h3>Exámenes enero/febrero</h3>";
                 dateCounter = 1;
             } else if (index === 4) {
-                result.innerHTML += `<h3 style="margin-top: 20px;">Exámenes julio/agosto</h3>`;
+                result.innerHTML += "<h3>Exámenes julio/agosto</h3>";
                 dateCounter = 1;
             }
 

--- a/style.css
+++ b/style.css
@@ -75,7 +75,7 @@
         #result {
             display: none;
             margin-top: 20px;
-            padding: 15px;
+            padding: 20px;
             background: #e0f2fe;
             color: #0c4a6e;
             border-radius: 8px;

--- a/style.css
+++ b/style.css
@@ -83,6 +83,12 @@
             line-height: 1.6;
         }
 
+
+        /* Estilos de los titulares de exámenes */
+        #result h3:not(:first-child) {
+            margin-top: 20px;
+        }
+
         /* Estilo del footer */
         footer {
             width: 100%;


### PR DESCRIPTION
Tras notar que el espaciado de la muestra de fechas era mayor en la parte superior que en la inferior, analice en el código en los h3 de result se les agrega un `margin-top: 20px", el cual al estar en todos genera que el primer h3 tenga un espaciado de 15px más debido al padding. 
Sabiendo lo anterior y entendiendo que hay varias soluciones más "rápidas/fáciles" tales como:
    - colocarle un `margin-top: 5px;` al primer h3.
    - cambiar el padding en result para que en top sea 0.

Decidí implementar lo siguiente:
    - Eliminar los `margin-top: 20px` de h3 en  *script.js*.
    - Establecer en el css el `margin-top: 20px` para todos los h3 en result exceptuando al primer elemento h3.
    - Modificar el padding de result pasandolo de 15px a 20px.

## Comparativa
### Vista actual:
![image](https://github.com/user-attachments/assets/5c2b68ee-9d97-4d63-9a20-db2e245bab91)

### Con los cambios:
![image](https://github.com/user-attachments/assets/f245955b-0b9f-4b5d-9e78-1625a1e9315f)

